### PR TITLE
Quick fixes to be able to build again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 # nginx HTTP Server
 #
-# VERSION 0.0.1
 
-FROM debian:wheezy
+FROM debian:jessie
 
 MAINTAINER Timo Derstappen, Marian Steinbach <marian@giantswarm.io>
 
@@ -12,9 +11,9 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # configure apt
 RUN apt-key adv --keyserver pgp.mit.edu --recv-keys 573BFD6B3D8FBC641079A6ABABF5BD827BD9BF62
-RUN echo "deb http://nginx.org/packages/mainline/debian/ wheezy nginx" >> /etc/apt/sources.list
+RUN echo "deb http://nginx.org/packages/mainline/debian/ jessie nginx" >> /etc/apt/sources.list
 
-ENV NGINX_VERSION 1.7.12-1~wheezy
+ENV NGINX_VERSION 1.9.0-1~jessie
 
 RUN apt-get update -q && \
     apt-get -y -q --no-install-recommends install nginx=${NGINX_VERSION} && \


### PR DESCRIPTION
1.7.12-1~wheezy was no longer available. To be able to build I had to
pick changes which were already prepared in the may-iteration branch.
