### PR TITLE
Add docs.giantswarm.io hostname

### DIFF
--- a/kubernetes/proxy-ingress.yaml
+++ b/kubernetes/proxy-ingress.yaml
@@ -16,6 +16,14 @@ spec:
           serviceName: proxy
           servicePort: 8000
         path: /
+  - host: docs.giantswarm.io
+    http:
+      paths:
+      - backend:
+          serviceName: proxy
+          servicePort: 8000
+        path: /
   tls:
   - hosts:
     - docs-g8s.giantswarm.io
+    - docs.giantswarm.io


### PR DESCRIPTION
This is needed to serve the canonical `docs.giantswarm.io` domain name