### PR TITLE
Removing old host name

### DIFF
--- a/kubernetes/proxy-ingress.yaml
+++ b/kubernetes/proxy-ingress.yaml
@@ -9,13 +9,6 @@ metadata:
     ingress.kubernetes.io/ssl-passthrough: "true"
 spec:
   rules:
-  - host: docs-g8s.giantswarm.io
-    http:
-      paths:
-      - backend:
-          serviceName: proxy
-          servicePort: 8000
-        path: /
   - host: docs.giantswarm.io
     http:
       paths:
@@ -25,5 +18,4 @@ spec:
         path: /
   tls:
   - hosts:
-    - docs-g8s.giantswarm.io
     - docs.giantswarm.io


### PR DESCRIPTION
After migration, the old host name is now no longer needed