### PR TITLE
Fixing issue #16: Use port 8000 instead of "http"

### DIFF
--- a/kubernetes/proxy-service.yaml
+++ b/kubernetes/proxy-service.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   ports:
     - port: 8000
-      targetPort: http
+      targetPort: 8000
   selector:
     app: docs
     component: proxy


### PR DESCRIPTION
See https://github.com/giantswarm/docs-proxy/issues/16
