### PR TITLE
update nginx annotation

### DIFF
--- a/helm/docs-proxy-chart/templates/ingress.yaml
+++ b/helm/docs-proxy-chart/templates/ingress.yaml
@@ -7,6 +7,7 @@ metadata:
     app: docs
   annotations:
     ingress.kubernetes.io/ssl-passthrough: "true"
+    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
 spec:
   rules:
   - host: docs.giantswarm.io


### PR DESCRIPTION
duplicating to support both the new cluster/IC and the old still running one, a subsequent PR should remove the old annotation after we have moved DNS and removed the old frontend cluster