### PR TITLE
Use Let's Encrypt cert for docs

### DIFF
--- a/helm/docs-proxy-chart/templates/ingress.yaml
+++ b/helm/docs-proxy-chart/templates/ingress.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: docs
   labels:
     app: docs
+  annotations:
+    certmanager.k8s.io/cluster-issuer: letsencrypt-prod
+    kubernetes.io/tls-acme: "true"
 spec:
   rules:
   - host: docs.giantswarm.io
@@ -17,4 +20,4 @@ spec:
   tls:
   - hosts:
     - docs.giantswarm.io
-    secretName: tls-secret
+    secretName: docs-proxy


### PR DESCRIPTION
For https://github.com/giantswarm/giantswarm/issues/4328

This changes the Ingress resource for docs-proxy (`https://docs.giantswarm.io/`) to use the Let's Encrypt cert provisioned automatically through cert-manager.