### PR TITLE
Add redirect for /basics/byoc/

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -48,6 +48,7 @@ http {
         rewrite   ^/guides/prepare-aws-account-for-guest-clusters/$         https://docs.giantswarm.io/guides/prepare-aws-account-for-tenant-clusters/         redirect;
         rewrite   ^/reference/giantswarm-aws-architecture/$                 https://docs.giantswarm.io/basics/aws-architecture/                                redirect;
         rewrite   ^/reference/giantswarm-onprem-architecture/$              https://docs.giantswarm.io/basics/onprem-architecture/                             redirect;
+        rewrite   ^/basics/byoc/$                                           https://docs.giantswarm.io/basics/multi-account/                                   redirect;
 
         location /robots.txt {
             root /www;


### PR DESCRIPTION
There was no redirect for the old BYOC URL yet. Added it.