### PR TITLE
Add server_tokens off; to nginx.conf

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -24,6 +24,8 @@ http {
         '"$remote_addr" "$http_x_forwarded_for" '
         '"$http_user_agent" "$http_referer"';
 
+    server_tokens off;
+
     # Configuration for the server
     server {
 


### PR DESCRIPTION
Aligning this repo to giantswarm/giantswarmio-nginx#40 (giantswarm/giantswarm#13146)

This PR disables sending the nginx server version through headers and error pages.