### PR TITLE
Add redirect for removed FAQ page

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -52,6 +52,9 @@ http {
         rewrite   ^/reference/giantswarm-onprem-architecture/$              https://docs.giantswarm.io/basics/onprem-architecture/                             redirect;
         rewrite   ^/basics/byoc/$                                           https://docs.giantswarm.io/basics/multi-account/                                   redirect;
 
+        # Removed FAQ page
+        rewrite   ^/faq/$                                                   https://docs.giantswarm.io/                                                        permanent;
+
         location /robots.txt {
             root /www;
         }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/10731