### PR TITLE
Remove /searchapi/status endpoint

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -74,14 +74,6 @@ http {
                 deny all;
             }
         }
-        location /searchapi/status {
-            auth_basic "Status Monitoring";
-            auth_basic_user_file /etc/nginx/htpasswd_admin;
-            proxy_pass http://SEARCH/docs/_status;
-            limit_except GET {
-                deny all;
-            }
-        }
 
         # proxy for search queries
         location /searchapi {


### PR DESCRIPTION
In the elasticsearch version we use, the endpoint `/<index>/_status` no longer exists, so this PR removes the according endpoint in our docs-proxy.

See https://www.elastic.co/guide/en/elasticsearch/reference/6.8/indices-status.html