### PR TITLE
Use $host instead of the Host header from incoming request

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -30,7 +30,7 @@ http {
         # Running port
         listen 8000;
 
-        proxy_set_header Host       $http_host;   # required for docker client's sake
+        proxy_set_header Host       $host;   # required for docker client's sake
         proxy_set_header X-Real-IP  $remote_addr; # pass on real client's IP
         proxy_set_header Authorization "";
 


### PR DESCRIPTION
Related to https://github.com/giantswarm/giantswarm/issues/11200

The `$http_host` variable is read from the `Host:` header of the incoming request. This allows a user to spoof this value when the header is set for the upstream service. It is better to use the server's own identity unless some upstream routing needs the original value (which is likely also problematic in itself)