### PR TITLE
Add redirect for MAPI CRD reference

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -46,6 +46,7 @@ http {
         # Redirects template
 
         rewrite   ^/reference/cp-k8s-api/([^/]+)$                           https://docs.giantswarm.io/ui-api/management-api/crd/$1/                     redirect;
+        rewrite   ^/guides/importing-certificates$                          https://docs.giantswarm.io/getting-started/ca-certificate/                   redirect;
 
         rewrite   ^/basics/kubernetes-fundamentals/$                        https://docs.giantswarm.io/kubernetes/resources/                             permanent;
         rewrite   ^/api$                                                    https://docs.giantswarm.io/api/                                              redirect;


### PR DESCRIPTION
This is supposed to fix a redirect loop happening currently when coming from old CRD URLs without trailing slash.

Found it out via Google Search Console.

Test:

```
curl -I https://docs.giantswarm.io/reference/cp-k8s-api/awsclusters.infrastructure.giantswarm.io
```