### PR TITLE
Fix access to RSS

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -105,21 +105,6 @@ http {
             proxy_pass http://CONTENT;
         }
 
-        # CORS headers for RSS feeds
-        location ~* index\.xml$ {
-            add_header 'Access-Control-Allow-Origin' '*';
-            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-            add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
-            add_header 'Access-Control-Allow-Credentials' 'true';
-
-            if ($request_method = 'OPTIONS') {
-                add_header 'Access-Control-Max-Age' 1728000;
-                add_header 'Content-Type' 'text/plain charset=UTF-8';
-                add_header 'Content-Length' 0;
-                return 204;
-            }
-        }
-
         location /_error {
             root /www;
             internal;
@@ -144,6 +129,25 @@ http {
             add_header X-Content-Type-Options "nosniff" always;
             add_header Referrer-Policy "no-referrer-when-downgrade" always;
         }
+
+        # CORS headers for RSS feeds
+        location ~* index\.xml$ {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+            add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+            add_header 'Access-Control-Allow-Credentials' 'true';
+
+            if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Max-Age' 1728000;
+                add_header 'Content-Type' 'text/plain charset=UTF-8';
+                add_header 'Content-Length' 0;
+                return 204;
+            }
+
+            proxy_pass http://CONTENT;
+            proxy_intercept_errors on;
+        }
+
 
         location / {
             proxy_pass http://CONTENT;


### PR DESCRIPTION
This PR fixes a problem introduced with my recent change which added CORS headers to RSS URLs, ending up in all RSS requests resulting in a 404.

The location block was missing the `proxy_pass` part.