### PR TITLE
Set ingressClassName in docs.giantswarm.io Ingress

### DIFF
--- a/helm/docs-proxy-app/templates/ingress.yaml
+++ b/helm/docs-proxy-app/templates/ingress.yaml
@@ -7,10 +7,10 @@ metadata:
     app: {{ .Values.name }}
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-giantswarm
-    kubernetes.io/ingress.class: nginx
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
+  ingressClassName: nginx
   rules:
     {{- $serviceName := .Values.name -}}
     {{- range .Values.hostnames }}


### PR DESCRIPTION
To prepare for NGINX ingress controller v1.0.0