### PR TITLE
Reduce DNS cache TTL by adding resolver config to upstream entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added resolver entries to configuration
+
 ## [1.1.0] - 2021-12-13
 
 ### Changed

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,12 +11,15 @@ http {
     # List of application servers
     upstream CONTENT {
         server docs-app:8080;
+        resolver coredns.kube-system valid=30s;
     }
     upstream APISPEC {
         server api-spec-app:8000;
+        resolver coredns.kube-system valid=30s;
     }
     upstream SEARCH {
         server sitesearch-app:9200;
+        resolver coredns.kube-system valid=30s;
     }
 
     log_format  custom  '"$request" '

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,15 +11,12 @@ http {
     # List of application servers
     upstream CONTENT {
         server docs-app:8080;
-        resolver coredns.kube-system valid=30s;
     }
     upstream APISPEC {
         server api-spec-app:8000;
-        resolver coredns.kube-system valid=30s;
     }
     upstream SEARCH {
         server sitesearch-app:9200;
-        resolver coredns.kube-system valid=30s;
     }
 
     log_format  custom  '"$request" '
@@ -34,6 +31,9 @@ http {
 
         # Running port
         listen 8000;
+
+        # Limit caching of internal DNS entries to 30 seconds
+        resolver coredns.kube-system.svc.cluster.local valid=30s;
 
         proxy_set_header Host       $http_host;   # required for docker client's sake
         proxy_set_header X-Real-IP  $remote_addr; # pass on real client's IP


### PR DESCRIPTION
To influence DNS caches and make them short-lived