### PR TITLE
Fix deployment

### DIFF
--- a/helm/docs-proxy-app/templates/deployment.yaml
+++ b/helm/docs-proxy-app/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
 
       containers:
         - name: {{ .Values.image.name }}
-          image: quay.io/giantswarm/{{ .Values.image.name }}:{{ .Values.image.sha }}
+          image: quay.io/giantswarm/{{ .Values.image.name }}:{{ .Values.image.tag }}
 
           ports:
             - containerPort: 8000

--- a/helm/docs-proxy-app/values.yaml
+++ b/helm/docs-proxy-app/values.yaml
@@ -3,7 +3,6 @@ namespace: docs
 image:
   name: docs-proxy
   tag: "[[.Version]]"
-  sha: "[[.SHA]]"
 hostnames:
 - docs.giantswarm.io
 - docs.c68pn.k8s.gollum.westeurope.azure.gigantic.io


### PR DESCRIPTION
With the change of the CircleCI config to using architect-orb, the docker image tagging scheme has also changed. This PR is required so the image can be found.