### PR TITLE
Add authentication routing rules for internal search

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -18,6 +18,9 @@ http {
     upstream SEARCH {
         server sitesearch-app:9200;
     }
+    upstream INTERNAL_SEARCH {
+        server internal-search-proxy-app:9200;
+    }
 
     log_format  custom  '"$request" '
         '$status $body_bytes_sent $request_time '
@@ -77,6 +80,9 @@ http {
 
         # proxy for search queries
         location /searchapi {
+            if ($cookie__oauth2_proxy) {
+                proxy_pass "http://INTERNAL_SEARCH/docs,blog,more/_search";
+            }
             proxy_pass "http://SEARCH/docs,blog/_search";
             limit_except GET POST {
                 deny all;

--- a/nginx.conf
+++ b/nginx.conf
@@ -78,10 +78,9 @@ http {
             }
         }
 
-        # if the request contains a cookie named '_oauth2_proxy', then
-        # rewrite /searchapi to /internal-searchapi
+        # always use internal search if authentication cookie is present
         if ($cookie__oauth2_proxy != "") {
-            rewrite ^/searchapi/(.*)$ /internal-searchapi/$1 break;
+            rewrite ^/searchapi(.*)$ /internal-searchapi$1 break;
         }
 
         # proxy for search queries
@@ -92,8 +91,9 @@ http {
             }
         }
 
+        # proxy for internal search queries
         location /internal-searchapi {
-            proxy_pass "http://INTERNAL_SEARCH/internal/_search";
+            proxy_pass "http://INTERNAL_SEARCH/docs,blog,more/_search";
             limit_except GET POST {
                 deny all;
             }

--- a/nginx.conf
+++ b/nginx.conf
@@ -78,14 +78,15 @@ http {
             }
         }
 
-        # always use internal search if authentication cookie is present
+        # always use internal search if authentication cookie (_oauth2_proxy)
+        # is present
         if ($cookie__oauth2_proxy != "") {
             rewrite ^/searchapi(.*)$ /internal-searchapi$1 break;
         }
 
         # proxy for search queries
         location /searchapi {
-            proxy_pass "http://SEARCH/docs,blog,less/_search";
+            proxy_pass "http://SEARCH/docs,blog/_search";
             limit_except GET POST {
                 deny all;
             }
@@ -93,7 +94,7 @@ http {
 
         # proxy for internal search queries
         location /internal-searchapi {
-            proxy_pass "http://INTERNAL_SEARCH/docs,blog,more/_search";
+            proxy_pass "http://INTERNAL_SEARCH/docs,blog/_search";
             limit_except GET POST {
                 deny all;
             }

--- a/nginx.conf
+++ b/nginx.conf
@@ -93,7 +93,7 @@ http {
         }
 
         location /internal-searchapi {
-            proxy_pass "http://INTERNAL_SEARCH/docs,blog,more/_search";
+            proxy_pass "http://INTERNAL_SEARCH/internal/_search";
             limit_except GET POST {
                 deny all;
             }

--- a/nginx.conf
+++ b/nginx.conf
@@ -19,7 +19,7 @@ http {
         server sitesearch-app:9200;
     }
     upstream INTERNAL_SEARCH {
-        server internal-search-proxy-app:9200;
+        server internal-search-proxy-app:4180;
     }
 
     log_format  custom  '"$request" '

--- a/nginx.conf
+++ b/nginx.conf
@@ -78,12 +78,22 @@ http {
             }
         }
 
+        # if the request contains a cookie named '_oauth2_proxy', then
+        # rewrite /searchapi to /internal-searchapi
+        if ($cookie__oauth2_proxy != "") {
+            rewrite ^/searchapi/(.*)$ /internal-searchapi/$1 break;
+        }
+
         # proxy for search queries
         location /searchapi {
-            if ($cookie__oauth2_proxy) {
-                proxy_pass "http://INTERNAL_SEARCH/docs,blog,more/_search";
+            proxy_pass "http://SEARCH/docs,blog,less/_search";
+            limit_except GET POST {
+                deny all;
             }
-            proxy_pass "http://SEARCH/docs,blog/_search";
+        }
+
+        location /internal-searchapi {
+            proxy_pass "http://INTERNAL_SEARCH/docs,blog,more/_search";
             limit_except GET POST {
                 deny all;
             }


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1597

This PR adds an additional endpoint `/internal-searchapi`, which passes requests to an `oauth2-proxy` instance. There the `_oauth2_proxy` cookie is validated and on success the request will be forwarded to the `sitesearch` app.
Additionally, requests going to `/searchapi` will be automatically rerouted to `/internal-searchapi`, in case the `_oauth2_proxy` cookie is present.