### PR TITLE
Revert "Add authentication routing rules for internal search"

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -18,9 +18,6 @@ http {
     upstream SEARCH {
         server sitesearch-app:9200;
     }
-    upstream INTERNAL_SEARCH {
-        server internal-search-proxy-app:4180;
-    }
 
     log_format  custom  '"$request" '
         '$status $body_bytes_sent $request_time '
@@ -78,23 +75,9 @@ http {
             }
         }
 
-        # always use internal search if authentication cookie (_oauth2_proxy)
-        # is present
-        if ($cookie__oauth2_proxy != "") {
-            rewrite ^/searchapi(.*)$ /internal-searchapi$1 break;
-        }
-
         # proxy for search queries
         location /searchapi {
             proxy_pass "http://SEARCH/docs,blog/_search";
-            limit_except GET POST {
-                deny all;
-            }
-        }
-
-        # proxy for internal search queries
-        location /internal-searchapi {
-            proxy_pass "http://INTERNAL_SEARCH/docs,blog/_search";
             limit_except GET POST {
                 deny all;
             }


### PR DESCRIPTION
Reverts giantswarm/docs-proxy#81

The authenticated search requests end up in `sitesearch` with `/internal-searchapi`. But `sitesearch` can only handle `/searchapi`. 