### PR TITLE
Add rerouting rules for internal search

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -18,6 +18,9 @@ http {
     upstream SEARCH {
         server sitesearch-app:9200;
     }
+    upstream INTERNAL_SEARCH {
+        server internal-search-proxy-app:4180;
+    }
 
     log_format  custom  '"$request" '
         '$status $body_bytes_sent $request_time '
@@ -75,9 +78,25 @@ http {
             }
         }
 
+        # always use internal search if authentication cookie (_oauth2_proxy)
+        # is present
+        if ($cookie__oauth2_proxy != "") {
+            rewrite ^/searchapi(.*)$ /internal-searchapi$1 break;
+        }
+
         # proxy for search queries
         location /searchapi {
             proxy_pass "http://SEARCH/docs,blog/_search";
+            limit_except GET POST {
+                deny all;
+            }
+        }
+
+        # proxy for internal search queries
+        location /internal-searchapi {
+            rewrite ^/internal-searchapi(.*)$ /searchapi$1 break;
+
+            proxy_pass "http://INTERNAL_SEARCH/docs,blog/_search";
             limit_except GET POST {
                 deny all;
             }


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1597
Revision of https://github.com/giantswarm/docs-proxy/pull/81

The problem with #81 was, that the sitesearch app always expected requests to `/searchapi`, but internal search requests were going to `/internal-searchapi`. This revision fixes the problem, by using rewrites.