### PR TITLE
Add rerouting rules for internal search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added internal search upstream endpoint.
+
+### Changed
+
+- Reroute requests from `/searchapi` to `/internal-searchapi`, if `_oauth2_proxy` cookie is present.
+
 ## [1.2.3] - 2022-12-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Reroute requests from `/searchapi` to `/internal-searchapi`, if `_oauth2_proxy` cookie is present.
 
-
 ## [1.2.3] - 2022-12-02
 
 ### Changed

--- a/nginx.conf
+++ b/nginx.conf
@@ -81,6 +81,8 @@ http {
         # always use internal search if authentication cookie (_oauth2_proxy)
         # is present
         if ($cookie__oauth2_proxy != "") {
+            # using proxy pass in if is unsafe, therefore we need to use rewrite
+            # https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/
             rewrite ^/searchapi(.*)$ /internal-searchapi$1 break;
         }
 
@@ -94,9 +96,12 @@ http {
 
         # proxy for internal search queries
         location /internal-searchapi {
-            rewrite ^/internal-searchapi(.*)$ /searchapi$1 break;
+            # When using rewrite the path part of the proxy_pass uri is ignored.
+            # e.g. "http://SEARCH/<this is ignored>";
+            # Therefore we specify it with another rewrite
+            rewrite ^/internal-searchapi(.*)$ /docs,blog/_search break;
 
-            proxy_pass "http://INTERNAL_SEARCH/docs,blog/_search";
+            proxy_pass "http://INTERNAL_SEARCH";
             limit_except GET POST {
                 deny all;
             }

--- a/nginx.conf
+++ b/nginx.conf
@@ -18,6 +18,9 @@ http {
     upstream SEARCH {
         server sitesearch-app:9200;
     }
+    upstream INTERNAL_SEARCH {
+        server internal-search-proxy-app:4180;
+    }
 
     log_format  custom  '"$request" '
         '$status $body_bytes_sent $request_time '
@@ -75,9 +78,25 @@ http {
             }
         }
 
+        # always use internal search if authentication cookie (_oauth2_proxy)
+        # is present
+        if ($cookie__oauth2_proxy != "") {
+            rewrite ^/searchapi(.*)$ /internal-searchapi$1 break;
+        }
+
         # proxy for search queries
         location /searchapi {
             proxy_pass "http://SEARCH/docs,blog/_search";
+            limit_except GET POST {
+                deny all;
+            }
+        }
+
+        # proxy for internal search queries
+        location /internal-searchapi {
+            rewrite ^/internal-searchapi(.*)$ /searchapi$1 break;
+
+            proxy_pass "http://INTERNAL_SEARCH/docs,blog/_search";
             limit_except GET POST {
                 deny all;
             }


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1597
Revision of https://github.com/giantswarm/docs-proxy/pull/87

The problem with the first two PRs was that the path specified in the URI of a `proxy_pass` call is ignored, as soon, `rewrite` is used.  More specifically the result of `rewrite` determines the path.
e.g. `"http://SEARCH/<this is ignored>";`

In previous PRs the Nginx configuration contained.
```
if ($cookie__oauth2_proxy != "") {
    rewrite ^/searchapi(.*)$ /internal-searchapi$1 break;
}
...
location /internal-searchapi {
    rewrite ^/internal-searchapi(.*)$ /searchapi$1 break;
    proxy_pass "http://INTERNAL_SEARCH/docs,blog/_search";
...
}
```
This means Nginx proxied requests from `/internal-searchapi` to `http://INTERNAL_SEARCH/searchapi` and not `http://INTERNAL_SEARCH/docs,blog/_search`.

This PR fixes that problem by specifying the desired path in the `rewrite` call and not in the `proxy_pass` call.