### PR TITLE
Enable CORS, cover intranet index

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -90,7 +90,7 @@ http {
         location ~* /searchapi/.*$ {
             add_header 'Access-Control-Allow-Origin' '*';
             add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-            add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+            add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS, POST';
             add_header 'Access-Control-Allow-Credentials' 'true';
             if ($request_method = 'OPTIONS') {
                 add_header 'Access-Control-Max-Age' 1728000;

--- a/nginx.conf
+++ b/nginx.conf
@@ -88,6 +88,17 @@ http {
 
         # proxy for search queries
         location /searchapi {
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+            add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+            add_header 'Access-Control-Allow-Credentials' 'true';
+            if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Max-Age' 1728000;
+                add_header 'Content-Type' 'text/plain charset=UTF-8';
+                add_header 'Content-Length' 0;
+                return 204;
+            }
+
             proxy_pass "http://SEARCH/docs,blog/_search";
             limit_except GET POST {
                 deny all;

--- a/nginx.conf
+++ b/nginx.conf
@@ -88,6 +88,18 @@ http {
 
         # proxy for search queries
         location /searchapi {
+            # Handle CORS for requests coming from the intranet.
+            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+            add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+            add_header 'Access-Control-Allow-Credentials' 'true';
+            if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Max-Age' 1728000;
+                add_header 'Content-Type' 'text/plain charset=UTF-8';
+                add_header 'Content-Length' 0;
+                return 204;
+            }
+            
             proxy_pass "http://SEARCH/docs,blog/_search";
             limit_except GET POST {
                 deny all;

--- a/nginx.conf
+++ b/nginx.conf
@@ -98,15 +98,20 @@ http {
                 add_header 'Content-Length' 0;
                 return 204;
             }
-        }
 
-        # proxy for search queries
-        location /searchapi {
             proxy_pass "http://SEARCH/docs,blog/_search";
             limit_except GET POST {
                 deny all;
             }
         }
+
+        # proxy for search queries
+        # location /searchapi {
+        #     proxy_pass "http://SEARCH/docs,blog/_search";
+        #     limit_except GET POST {
+        #         deny all;
+        #     }
+        # }
 
         # proxy for internal search queries
         location /internal-searchapi {

--- a/nginx.conf
+++ b/nginx.conf
@@ -105,7 +105,7 @@ http {
                 return 200;
             }
 
-            rewrite ^/searchapi/.* /docs,blog/_search"
+            rewrite ^/searchapi/.* /docs,blog/_search
             proxy_pass "http://SEARCH"
 
             limit_except GET POST OPTIONS HEAD {

--- a/nginx.conf
+++ b/nginx.conf
@@ -29,6 +29,13 @@ http {
 
     server_tokens off;
 
+    # Origins for CORS
+    map $http_referer $alloworigin {
+        ^(.+)/$ $1;
+        ^(.+)[^/]$ $1;
+        default "";
+    }
+
     # Configuration for the server
     server {
 
@@ -88,14 +95,13 @@ http {
 
         # proxy for search queries
         location /searchapi {
-            add_header 'Access-Control-Allow-Origin' '*';
-            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+            add_header 'Access-Control-Allow-Origin' $alloworigin;
             add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS, POST';
             add_header 'Access-Control-Allow-Credentials' 'true';
             if ($request_method = 'OPTIONS') {
-                add_header 'Access-Control-Allow-Origin' '*';
+                add_header 'Access-Control-Allow-Origin' $alloworigin;
                 add_header 'Access-Control-Allow-Credentials' 'true';
-                add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+                add_header 'Access-Control-Allow-Headers' '*';
                 add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS, POST';
                 add_header 'Access-Control-Max-Age' 1728000;
                 add_header 'Content-Type' 'text/plain charset=UTF-8';

--- a/nginx.conf
+++ b/nginx.conf
@@ -93,7 +93,7 @@ http {
             rewrite ^/searchapi(.*)$ /internal-searchapi$1 break;
         }
 
-        location ~* /searchapi.*$ {
+        location ~* /searchapi/.*$ {
             if ($request_method ~* "(GET|POST)") {
                 add_header "Access-Control-Allow-Origin"  "*";
             }

--- a/nginx.conf
+++ b/nginx.conf
@@ -110,7 +110,7 @@ http {
             # When using rewrite the path part of the proxy_pass uri is ignored.
             # e.g. "http://SEARCH/<this is ignored>";
             # Therefore we specify it with another rewrite
-            rewrite ^/internal-searchapi(.*)$ /docs,blog/_search break;
+            rewrite ^/internal-searchapi(.*)$ /docs,blog,intranet/_search break;
 
             proxy_pass "http://INTERNAL_SEARCH";
             limit_except GET POST {

--- a/nginx.conf
+++ b/nginx.conf
@@ -104,15 +104,22 @@ http {
                 add_header "Access-Control-Allow-Headers" "Authorization, Origin, X-Requested-With, Content-Type, Accept";
                 return 200;
             }
-        }
 
-        # proxy for search queries
-        location /searchapi {
-            proxy_pass "http://SEARCH/docs,blog/_search";
-            limit_except GET POST {
+            rewrite ^/searchapi/.* /docs,blog/_search"
+            proxy_pass "http://SEARCH"
+
+            limit_except GET POST OPTIONS HEAD {
                 deny all;
             }
         }
+
+        # proxy for search queries
+        # location /searchapi {
+        #     proxy_pass "http://SEARCH/docs,blog/_search";
+        #     limit_except GET POST {
+        #         deny all;
+        #     }
+        # }
 
         # proxy for internal search queries
         location /internal-searchapi {

--- a/nginx.conf
+++ b/nginx.conf
@@ -86,9 +86,8 @@ http {
             rewrite ^/searchapi(.*)$ /internal-searchapi$1 break;
         }
 
-        # proxy for search queries
-        location /searchapi {
-            # Handle CORS for requests coming from the intranet.
+        # Handle CORS for requests coming from the intranet.
+        location ~* /searchapi/.*$ {
             add_header 'Access-Control-Allow-Origin' '*';
             add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
             add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
@@ -99,7 +98,10 @@ http {
                 add_header 'Content-Length' 0;
                 return 204;
             }
-            
+        }
+
+        # proxy for search queries
+        location /searchapi {
             proxy_pass "http://SEARCH/docs,blog/_search";
             limit_except GET POST {
                 deny all;
@@ -108,18 +110,6 @@ http {
 
         # proxy for internal search queries
         location /internal-searchapi {
-            # Handle CORS for requests coming from the intranet.
-            add_header 'Access-Control-Allow-Origin' '*';
-            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-            add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
-            add_header 'Access-Control-Allow-Credentials' 'true';
-            if ($request_method = 'OPTIONS') {
-                add_header 'Access-Control-Max-Age' 1728000;
-                add_header 'Content-Type' 'text/plain charset=UTF-8';
-                add_header 'Content-Length' 0;
-                return 204;
-            }
-
             # When using rewrite the path part of the proxy_pass uri is ignored.
             # e.g. "http://SEARCH/<this is ignored>";
             # Therefore we specify it with another rewrite

--- a/nginx.conf
+++ b/nginx.conf
@@ -105,8 +105,8 @@ http {
                 return 200;
             }
 
-            rewrite ^/searchapi/.* /docs,blog/_search
-            proxy_pass "http://SEARCH"
+            rewrite ^/searchapi/.* /docs,blog/_search;
+            proxy_pass "http://SEARCH";
 
             limit_except GET POST OPTIONS HEAD {
                 deny all;

--- a/nginx.conf
+++ b/nginx.conf
@@ -117,7 +117,19 @@ http {
 
         # proxy for internal search queries
         location /internal-searchapi {
-            add_header 'Access-Control-Allow-Origin' '*';
+            add_header 'Access-Control-Allow-Origin' $alloworigin;
+            add_header 'Access-Control-Allow-Methods' 'POST, GET, OPTIONS';
+            add_header 'Access-Control-Allow-Credentials' 'true';
+            if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Allow-Origin' $alloworigin;
+                add_header 'Access-Control-Allow-Credentials' 'true';
+                add_header 'Access-Control-Allow-Headers' 'Accept,Accept-Language,Authority,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+                add_header 'Access-Control-Allow-Methods' 'POST, GET, OPTIONS';
+                add_header 'Access-Control-Max-Age' 1728000;
+                add_header 'Content-Type' 'text/plain charset=UTF-8';
+                add_header 'Content-Length' 0;
+                return 204;
+            }
 
             # When using rewrite the path part of the proxy_pass uri is ignored.
             # e.g. "http://SEARCH/<this is ignored>";

--- a/nginx.conf
+++ b/nginx.conf
@@ -95,11 +95,11 @@ http {
 
         # proxy for search queries
         location /searchapi {
-            add_header 'Access-Control-Allow-Origin' $alloworigin;
+            add_header 'Access-Control-Allow-Origin' 'localhost';
             add_header 'Access-Control-Allow-Methods' 'POST, GET, OPTIONS';
             add_header 'Access-Control-Allow-Credentials' 'true';
             if ($request_method = 'OPTIONS') {
-                add_header 'Access-Control-Allow-Origin' $alloworigin;
+                add_header 'Access-Control-Allow-Origin' 'localhost';
                 add_header 'Access-Control-Allow-Credentials' 'true';
                 add_header 'Access-Control-Allow-Headers' 'Accept,Accept-Language,Authority,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
                 add_header 'Access-Control-Allow-Methods' 'POST, GET, OPTIONS';
@@ -117,11 +117,11 @@ http {
 
         # proxy for internal search queries
         location /internal-searchapi {
-            add_header 'Access-Control-Allow-Origin' $alloworigin;
+            add_header 'Access-Control-Allow-Origin' 'localhost';
             add_header 'Access-Control-Allow-Methods' 'POST, GET, OPTIONS';
             add_header 'Access-Control-Allow-Credentials' 'true';
             if ($request_method = 'OPTIONS') {
-                add_header 'Access-Control-Allow-Origin' $alloworigin;
+                add_header 'Access-Control-Allow-Origin' 'localhost';
                 add_header 'Access-Control-Allow-Credentials' 'true';
                 add_header 'Access-Control-Allow-Headers' 'Accept,Accept-Language,Authority,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
                 add_header 'Access-Control-Allow-Methods' 'POST, GET, OPTIONS';

--- a/nginx.conf
+++ b/nginx.conf
@@ -98,20 +98,15 @@ http {
                 add_header 'Content-Length' 0;
                 return 204;
             }
+        }
 
+        # proxy for search queries
+        location /searchapi {
             proxy_pass "http://SEARCH/docs,blog/_search";
             limit_except GET POST {
                 deny all;
             }
         }
-
-        # proxy for search queries
-        # location /searchapi {
-        #     proxy_pass "http://SEARCH/docs,blog/_search";
-        #     limit_except GET POST {
-        #         deny all;
-        #     }
-        # }
 
         # proxy for internal search queries
         location /internal-searchapi {

--- a/nginx.conf
+++ b/nginx.conf
@@ -95,18 +95,15 @@ http {
 
         # proxy for search queries
         location /searchapi {
-            add_header 'Access-Control-Allow-Origin' 'localhost';
-            add_header 'Access-Control-Allow-Methods' 'POST, GET, OPTIONS';
-            add_header 'Access-Control-Allow-Credentials' 'true';
-            if ($request_method = 'OPTIONS') {
-                add_header 'Access-Control-Allow-Origin' 'localhost';
-                add_header 'Access-Control-Allow-Credentials' 'true';
-                add_header 'Access-Control-Allow-Headers' 'Accept,Accept-Language,Authority,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-                add_header 'Access-Control-Allow-Methods' 'POST, GET, OPTIONS';
-                add_header 'Access-Control-Max-Age' 1728000;
-                add_header 'Content-Type' 'text/plain charset=UTF-8';
-                add_header 'Content-Length' 0;
-                return 204;
+            if ($request_method ~* "(GET|POST)") {
+                add_header "Access-Control-Allow-Origin"  "*";
+            }
+
+            if ($request_method = OPTIONS ) {
+                add_header "Access-Control-Allow-Origin"  "*";
+                add_header "Access-Control-Allow-Methods" "GET, POST, OPTIONS, HEAD";
+                add_header "Access-Control-Allow-Headers" "Authorization, Origin, X-Requested-With, Content-Type, Accept";
+                return 200;
             }
 
             proxy_pass "http://SEARCH/docs,blog/_search";
@@ -117,20 +114,6 @@ http {
 
         # proxy for internal search queries
         location /internal-searchapi {
-            add_header 'Access-Control-Allow-Origin' 'localhost';
-            add_header 'Access-Control-Allow-Methods' 'POST, GET, OPTIONS';
-            add_header 'Access-Control-Allow-Credentials' 'true';
-            if ($request_method = 'OPTIONS') {
-                add_header 'Access-Control-Allow-Origin' 'localhost';
-                add_header 'Access-Control-Allow-Credentials' 'true';
-                add_header 'Access-Control-Allow-Headers' 'Accept,Accept-Language,Authority,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
-                add_header 'Access-Control-Allow-Methods' 'POST, GET, OPTIONS';
-                add_header 'Access-Control-Max-Age' 1728000;
-                add_header 'Content-Type' 'text/plain charset=UTF-8';
-                add_header 'Content-Length' 0;
-                return 204;
-            }
-
             # When using rewrite the path part of the proxy_pass uri is ignored.
             # e.g. "http://SEARCH/<this is ignored>";
             # Therefore we specify it with another rewrite

--- a/nginx.conf
+++ b/nginx.conf
@@ -86,22 +86,23 @@ http {
             rewrite ^/searchapi(.*)$ /internal-searchapi$1 break;
         }
 
-        # Handle CORS for requests coming from the intranet.
-        location ~* /searchapi/.*$ {
+        # proxy for search queries
+        location /searchapi {
             add_header 'Access-Control-Allow-Origin' '*';
             add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
             add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS, POST';
             add_header 'Access-Control-Allow-Credentials' 'true';
             if ($request_method = 'OPTIONS') {
+                add_header 'Access-Control-Allow-Origin' '*';
+                add_header 'Access-Control-Allow-Credentials' 'true';
+                add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+                add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS, POST';
                 add_header 'Access-Control-Max-Age' 1728000;
                 add_header 'Content-Type' 'text/plain charset=UTF-8';
                 add_header 'Content-Length' 0;
                 return 204;
             }
-        }
 
-        # proxy for search queries
-        location /searchapi {
             proxy_pass "http://SEARCH/docs,blog/_search";
             limit_except GET POST {
                 deny all;
@@ -110,6 +111,8 @@ http {
 
         # proxy for internal search queries
         location /internal-searchapi {
+            add_header 'Access-Control-Allow-Origin' '*';
+
             # When using rewrite the path part of the proxy_pass uri is ignored.
             # e.g. "http://SEARCH/<this is ignored>";
             # Therefore we specify it with another rewrite

--- a/nginx.conf
+++ b/nginx.conf
@@ -88,6 +88,15 @@ http {
 
         # proxy for search queries
         location /searchapi {
+            proxy_pass "http://SEARCH/docs,blog/_search";
+            limit_except GET POST {
+                deny all;
+            }
+        }
+
+        # proxy for internal search queries
+        location /internal-searchapi {
+            # Handle CORS for requests coming from the intranet.
             add_header 'Access-Control-Allow-Origin' '*';
             add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
             add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
@@ -99,14 +108,6 @@ http {
                 return 204;
             }
 
-            proxy_pass "http://SEARCH/docs,blog/_search";
-            limit_except GET POST {
-                deny all;
-            }
-        }
-
-        # proxy for internal search queries
-        location /internal-searchapi {
             # When using rewrite the path part of the proxy_pass uri is ignored.
             # e.g. "http://SEARCH/<this is ignored>";
             # Therefore we specify it with another rewrite

--- a/nginx.conf
+++ b/nginx.conf
@@ -96,13 +96,13 @@ http {
         # proxy for search queries
         location /searchapi {
             add_header 'Access-Control-Allow-Origin' $alloworigin;
-            add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS, POST';
+            add_header 'Access-Control-Allow-Methods' 'POST, GET, OPTIONS';
             add_header 'Access-Control-Allow-Credentials' 'true';
             if ($request_method = 'OPTIONS') {
                 add_header 'Access-Control-Allow-Origin' $alloworigin;
                 add_header 'Access-Control-Allow-Credentials' 'true';
-                add_header 'Access-Control-Allow-Headers' '*';
-                add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS, POST';
+                add_header 'Access-Control-Allow-Headers' 'Accept,Accept-Language,Authority,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+                add_header 'Access-Control-Allow-Methods' 'POST, GET, OPTIONS';
                 add_header 'Access-Control-Max-Age' 1728000;
                 add_header 'Content-Type' 'text/plain charset=UTF-8';
                 add_header 'Content-Length' 0;

--- a/nginx.conf
+++ b/nginx.conf
@@ -93,8 +93,7 @@ http {
             rewrite ^/searchapi(.*)$ /internal-searchapi$1 break;
         }
 
-        # proxy for search queries
-        location /searchapi {
+        location ~* /searchapi.*$ {
             if ($request_method ~* "(GET|POST)") {
                 add_header "Access-Control-Allow-Origin"  "*";
             }
@@ -105,7 +104,10 @@ http {
                 add_header "Access-Control-Allow-Headers" "Authorization, Origin, X-Requested-With, Content-Type, Accept";
                 return 200;
             }
+        }
 
+        # proxy for search queries
+        location /searchapi {
             proxy_pass "http://SEARCH/docs,blog/_search";
             limit_except GET POST {
                 deny all;


### PR DESCRIPTION
This PR should enable searching from the intranet.giantswarm.io context and would also expose content from the intranet index.

Towards https://github.com/giantswarm/giantswarm/issues/25054