### PR TITLE
Remove internal search and cors logic in searchapi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove internal search
+- Remove cors logic in `searchapi` location
+
 ## [1.3.4] - 2022-12-15
 
 ### Changed

--- a/nginx.conf
+++ b/nginx.conf
@@ -79,7 +79,7 @@ http {
         location /searchapi {
             proxy_pass "http://SEARCH/docs,blog/_search";
 
-            limit_except GET POST OPTIONS {
+            limit_except GET POST {
                 deny all;
             }
         }

--- a/nginx.conf
+++ b/nginx.conf
@@ -18,9 +18,6 @@ http {
     upstream SEARCH {
         server sitesearch-app:9200;
     }
-    upstream INTERNAL_SEARCH {
-        server internal-search-proxy-app:4180;
-    }
 
     log_format  custom  '"$request" '
         '$status $body_bytes_sent $request_time '
@@ -78,32 +75,8 @@ http {
             }
         }
 
-        # always use internal search if authentication cookie (_oauth2_proxy)
-        # is present
-        if ($cookie__oauth2_proxy != "") {
-            # using proxy pass in if is unsafe, therefore we need to use rewrite
-            # https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/
-            rewrite ^/searchapi(.*)$ /internal-searchapi$1 break;
-        }
-
         # proxy for search queries
         location /searchapi {
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Accept' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-            add_header 'Access-Control-Allow-Credentials' 'true' always;
-
-            if ($request_method = 'OPTIONS') {
-                add_header 'Access-Control-Allow-Origin' '*' always;
-                add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Accept' always;
-                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-                add_header 'Access-Control-Allow-Credentials' 'true' always;
-                add_header 'Access-Control-Max-Age' 1728000 always;
-                add_header 'Content-Type' 'text/plain charset=UTF-8' always;
-                add_header 'Content-Length' 0 always;
-                return 204;
-            }
-
             proxy_pass "http://SEARCH/docs,blog/_search";
 
             limit_except GET POST OPTIONS {
@@ -111,35 +84,6 @@ http {
             }
         }
 
-        # proxy for internal search queries
-        location /internal-searchapi {
-            # When using rewrite the path part of the proxy_pass uri is ignored.
-            # e.g. "http://SEARCH/<this is ignored>";
-            # Therefore we specify it with another rewrite
-            rewrite ^/internal-searchapi(.*)$ /docs,blog,intranet/_search break;
-
-            add_header 'Access-Control-Allow-Origin' '*' always;
-            add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Accept' always;
-            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-            add_header 'Access-Control-Allow-Credentials' 'true' always;
-
-            if ($request_method = 'OPTIONS') {
-                add_header 'Access-Control-Allow-Origin' '*' always;
-                add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Accept' always;
-                add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-                add_header 'Access-Control-Allow-Credentials' 'true' always;
-                add_header 'Access-Control-Max-Age' 1728000 always;
-                add_header 'Content-Type' 'text/plain charset=UTF-8' always;
-                add_header 'Content-Length' 0 always;
-                return 204;
-            }
-
-            proxy_pass "http://INTERNAL_SEARCH";
-
-            limit_except GET POST OPTIONS {
-                deny all;
-            }
-        }
 
         # Expires headers for static resources
         location /img {


### PR DESCRIPTION
The internal search routing logic will be dealt with in the nginx defined in the [intranet](https://github.com/giantswarm/giantswarm).

Additionally, we won't support cors requests to `/searchapi`.

Towards https://github.com/giantswarm/giantswarm/issues/25054