### PR TITLE
Update CircleCI configuration for pushing to container registries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,30 +3,13 @@ version: 2.1
 orbs:
   architect: giantswarm/architect@4.35.5
 
-jobs:
-  build:
-    executor: architect/architect
-    environment:
-      DOCKER_BUILDKIT: "1"
-
-    steps:
-      - checkout
-
-      - setup_remote_docker:
-          version: 20.10.11
-
-      - architect/push-to-docker:
-          image: quay.io/giantswarm/docs-proxy
-          tag-latest-branch: main
-          username_envar: QUAY_USERNAME
-          password_envar: QUAY_PASSWORD
-
 workflows:
-  package-and-push-chart-on-tag:
+  build-workflow:
     jobs:
-      - build:
+      - architect/push-to-registries:
           context: architect
-          filters:  # required since `architect/push-to-app-catalog` has tag filters AND requires `build`
+          name: push-to-registries
+          filters:
             tags:
               only: /.*/
 
@@ -36,6 +19,8 @@ workflows:
           app_catalog: giantswarm-operations-platform-catalog
           app_catalog_test: giantswarm-operations-platform-test-catalog
           chart: docs-proxy-app
+          requires:
+            - push-to-registries
           # Trigger job on git tag.
           filters:
             tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@4.35.1
+  architect: giantswarm/architect@4.35.5
 
 jobs:
   build:
@@ -14,7 +14,7 @@ jobs:
 
       - setup_remote_docker:
           version: 20.10.11
-      
+
       - architect/push-to-docker:
           image: quay.io/giantswarm/docs-proxy
           tag-latest-branch: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ workflows:
               only: /.*/
 
       - architect/push-to-app-catalog:
-          name: package and push
+          name: push-to-app-catalog
           context: architect
           app_catalog: giantswarm-operations-platform-catalog
           app_catalog_test: giantswarm-operations-platform-test-catalog
@@ -25,5 +25,3 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-          requires:
-            - build


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2979

This PR was created through automation by Team Honeybadger, to make sure that the container images built for this repository are available in the right registries.

For that, the CircleCI configuration is modified to use the new [push-to-registries](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) job instead of the old `push-to-docker`. This means that there is **only one job for all registry pushes**, and it simplifies the configuration by removing many parameters that are now set automatically or as defaults.

## Notes

- Since the PR is also changing the CircleCI job name to `push-to-registries`, the branch protection rules in this repository will likely require updating before the required checks can be green.
- Dev images are sent to ACR (gsoci.azurecr.io) and Quay currently. If you need dev images elsewhere, you can add the according configuration as described in the [documentation](https://github.com/giantswarm/architect-orb/blob/main/docs/job/push-to-registries.md) to the step configuration.

## To the responsible team

Please,

- Double-check the job dependecies (`requires`).
- Double-check the job `filters`. Especially if this PR replaces several jobs with one, and the previous jobs had different filters, make sure that the filter includes all cases.
- Update the changelog if you think this deserves a mention.
- Approve and merge this PR once it's ready. No need to wait for the author in this case.
- Get this done until 1st of December, so that we can move on with follow-up steps.