### PR TITLE
Add hostname docs.operations.awsprod.gigantic.io

### DIFF
--- a/helm/docs-proxy-app/values.yaml
+++ b/helm/docs-proxy-app/values.yaml
@@ -6,6 +6,7 @@ image:
 hostnames:
 - docs.giantswarm.io
 - docs.c68pn.k8s.gollum.westeurope.azure.gigantic.io
+- docs.operations.awsprod.gigantic.io
 
 global:
   podSecurityStandards:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29470

This adds a hostname for ingress on gazelle/operations.

Once this is deployed successfully, the outdated hostname will get removed.