### PR TITLE
Remove proxying to api-spec, add redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove proxying to api-spec server
+
+### Added
+
+- Add redirect to new api-spec location
+
 ## [1.5.5] - 2024-03-13
 
 ### Changed
@@ -19,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Disallow bots for docs revamp
+
 ## [1.5.3] - 2024-02-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ The main purpose is to
 
 - Route requests to their respective backends.
   - Route content URL requests to the content backend.
-  - Rest API documentation to the api-spec backend.
   - Route search requests to the search API server.
 - Respond to requests for some historic URLs and URL patterns with redirects.
 - Set some common expires headers for cache control.

--- a/nginx.conf
+++ b/nginx.conf
@@ -50,7 +50,6 @@ http {
         rewrite   ^/guides/securing-with-rbac-and-psp$                      https://docs.giantswarm.io/getting-started/rbac-and-psp/                     redirect;
 
         rewrite   ^/basics/kubernetes-fundamentals/$                        https://docs.giantswarm.io/kubernetes/resources/                             permanent;
-        rewrite   ^/api$                                                    https://docs.giantswarm.io/api/                                              redirect;
         rewrite   ^/guides/prepare-azure-subscription-for-guest-clusters/$  https://docs.giantswarm.io/getting-started/cloud-provider-accounts/azure/    redirect;
         rewrite   ^/guides/prepare-aws-account-for-guest-clusters/$         https://docs.giantswarm.io/getting-started/cloud-provider-accounts/aws/      redirect;
         rewrite   ^/reference/giantswarm-aws-architecture/$                 https://docs.giantswarm.io/general/architcture/aws/                          redirect;
@@ -59,6 +58,10 @@ http {
 
         # Removed FAQ page
         rewrite   ^/faq/$                                                   https://docs.giantswarm.io/                                                  permanent;
+
+        # Rest API documentation
+        rewrite   ^/api$    https://giantswarm.github.io/api-spec/   redirect;
+        rewrite   ^/api/$   https://giantswarm.github.io/api-spec/   redirect;
 
         location /robots.txt {
             root /www;

--- a/nginx.conf
+++ b/nginx.conf
@@ -12,9 +12,6 @@ http {
     upstream CONTENT {
         server docs-app:8080;
     }
-    upstream APISPEC {
-        server api-spec-app:8000;
-    }
     upstream SEARCH {
         server sitesearch-app:9200;
     }
@@ -111,21 +108,6 @@ http {
         location /healthz {
             add_header Content-Type text/plain;
             return 200 'Doing fine';
-        }
-
-        location /api {
-            # remove /api prefix from URI
-            rewrite ^/api/(.*)$ /$1 break;
-            proxy_pass http://APISPEC;
-            # Error pages
-            proxy_intercept_errors on;
-            error_page 403 /_error/403.html;
-            error_page 404 /_error/404.html;
-            error_page 500 502 503 504 /_error/50x.html;
-            add_header X-Frame-Options deny always;
-            add_header X-XSS-Protection "1; mode=block" always;
-            add_header X-Content-Type-Options "nosniff" always;
-            add_header Referrer-Policy "no-referrer-when-downgrade" always;
         }
 
         # CORS headers for RSS feeds


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/31561

Requires a release to become effective.

PR https://github.com/giantswarm/api-spec/pull/254 must be merged and GitHub pages should be ready before we merge this one.