### PR TITLE
fix: use .Chart.AppVersion for version labels and image tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use `.Chart.AppVersion` instead of `.Chart.Version` for the `application.giantswarm.io/branch` and `application.giantswarm.io/commit` labels and for the container image tag. When deployed as an OCI chart via Flux, the chart version carries build metadata (e.g. `1.9.7+bf8b0e6012b2`); the `+` produced invalid Kubernetes label values and an unpullable image tag. `.Chart.AppVersion` holds the clean release tag (`replace-app-version-with-git` is enabled), as recommended by the App Build Suite migration guide.
+
 ## [1.9.1] - 2026-05-18
 
 ## [1.9.0] - 2025-12-12

--- a/helm/docs-proxy-app/templates/_helpers.tpl
+++ b/helm/docs-proxy-app/templates/_helpers.tpl
@@ -18,8 +18,8 @@ Common labels
 */}}
 {{- define "labels.common" -}}
 {{ include "labels.selector" . }}
-application.giantswarm.io/branch: {{ .Chart.Version | replace "#" "-" | replace "/" "-" | replace "." "-" | trunc 63 | trimSuffix "-" | quote }}
-application.giantswarm.io/commit: {{ .Chart.Version | quote }}
+application.giantswarm.io/branch: {{ .Chart.AppVersion | replace "#" "-" | replace "/" "-" | replace "." "-" | trunc 63 | trimSuffix "-" | quote }}
+application.giantswarm.io/commit: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 application.giantswarm.io/team: {{ index .Chart.Annotations "io.giantswarm.application.team" | quote }}
 helm.sh/chart: {{ include "chart" . | quote }}
@@ -40,6 +40,6 @@ Define image tag.
 {{- if .Values.image.tag }}
 {{- .Values.image.tag }}
 {{- else }}
-{{- .Chart.Version }}
+{{- .Chart.AppVersion }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## What

The `application.giantswarm.io/branch` and `application.giantswarm.io/commit` labels in `_helpers.tpl`, and the `image.tag` helper fallback, templated `.Chart.Version`. When the chart is deployed as an OCI artifact via Flux, the chart version carries build metadata (e.g. `1.9.7+bf8b0e6012b2`), because Flux appends the artifact checksum to the chart version. The `+` then:

1. produced an invalid Kubernetes label value — the API server rejected the Deployment, breaking the Flux HelmRelease install and causing a docs.giantswarm.io outage (the failed install triggered uninstall remediation, deleting the running workload):
   ```
   Deployment.apps "docs-proxy-app" is invalid: metadata.labels: Invalid value: "1.9.7+bf8b0e6012b2"
   ```
2. would have produced an unpullable image tag `docs-proxy:1.9.7+bf8b0e6012b2` even after the label error was resolved.

## Change

Use `.Chart.AppVersion` instead of `.Chart.Version` for the two labels and the image tag. `replace-app-version-with-git: true` is already set in `.abs/main.yaml`, so `.Chart.AppVersion` holds the clean release tag (`1.9.7`) — Flux only appends the checksum to the chart *version*, not appVersion. The `helm.sh/chart` label keeps `.Chart.Version` (Helm convention; already sanitized with `replace "+" "_"`).

This follows the [ABS migration guide](https://github.com/giantswarm/giantswarm/blob/main/content/docs/dev-and-releng/app-build-suite/migration.md): *"Do not use the raw .Chart.Version field value for image tags, labels, etc."*

## Verification

Rendered the chart with `version: 1.9.7+bf8b0e6012b2` / `appVersion: 1.9.7`:

| field | before | after |
|---|---|---|
| `application.giantswarm.io/branch` | `1-9-7+bf8b0e6012b2` ❌ | `1-9-7` ✅ |
| `application.giantswarm.io/commit` | `1.9.7+bf8b0e6012b2` ❌ | `1.9.7` ✅ |
| image tag | `docs-proxy:1.9.7+bf8b0e6012b2` ❌ | `docs-proxy:1.9.7` ✅ |
| `helm.sh/chart` | `docs-proxy-app-1.9.7_bf8b0e6012b2` ✅ | `docs-proxy-app-1.9.7_bf8b0e6012b2` ✅ |

## Follow-up

Once released, the docs-proxy App CR → Flux HelmRelease migration (reverted in workload-clusters-fleet) can be re-attempted.