### PR TITLE
feat: add ephemeral-storage resource requests and limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use `.Chart.AppVersion` instead of `.Chart.Version` for the `application.giantswarm.io/branch` and `application.giantswarm.io/commit` labels and for the container image tag. When deployed as an OCI chart via Flux, the chart version carries build metadata (e.g. `1.9.7+bf8b0e6012b2`); the `+` produced invalid Kubernetes label values and an unpullable image tag. `.Chart.AppVersion` holds the clean release tag (`replace-app-version-with-git` is enabled), as recommended by the App Build Suite migration guide.
 
+### Added
+
+- Add `ephemeral-storage` resource requests and limits (Kyverno policy compliance).
+
+### Changed
+
+- Use binary suffix (`Mi`) for memory resource values.
+
 ### Removed
 
 - Remove the nginx `Ingress` template (and its `ingress` values/schema). Routing is handled by the Gateway API `HTTPRoute`; our clusters no longer run an nginx ingress controller (only the `alb` IngressClass exists), so the chart's hardcoded `ingressClassName: nginx` was rejected by the AWS Load Balancer Controller admission webhook (`IngressClass "nginx" not found`), which blocked HelmRelease installs.

--- a/helm/docs-proxy-app/templates/deployment.yaml
+++ b/helm/docs-proxy-app/templates/deployment.yaml
@@ -63,9 +63,11 @@ spec:
             requests:
               cpu: {{ .Values.resources.requests.cpu }}
               memory: {{ .Values.resources.requests.memory }}
+              ephemeral-storage: {{ .Values.resources.requests.ephemeralStorage }}
             limits:
               cpu: {{ .Values.resources.limits.cpu }}
               memory: {{ .Values.resources.limits.memory }}
+              ephemeral-storage: {{ .Values.resources.limits.ephemeralStorage }}
 
           livenessProbe:
             httpGet:

--- a/helm/docs-proxy-app/values.schema.json
+++ b/helm/docs-proxy-app/values.schema.json
@@ -36,6 +36,9 @@
                         },
                         "memory": {
                             "type": "string"
+                        },
+                        "ephemeralStorage": {
+                            "type": "string"
                         }
                     }
                 },
@@ -46,6 +49,9 @@
                             "type": "string"
                         },
                         "memory": {
+                            "type": "string"
+                        },
+                        "ephemeralStorage": {
                             "type": "string"
                         }
                     }

--- a/helm/docs-proxy-app/values.yaml
+++ b/helm/docs-proxy-app/values.yaml
@@ -10,7 +10,9 @@ hostnames:
 resources:
   requests:
     cpu: 10m
-    memory: 10M
+    memory: 10Mi
+    ephemeralStorage: 50Mi
   limits:
     cpu: 100m
-    memory: 50M
+    memory: 50Mi
+    ephemeralStorage: 200Mi


### PR DESCRIPTION
## What

Adds `ephemeral-storage` resource requests and limits to the docs-proxy deployment, and switches memory values to the binary suffix (`Mi`).

## Why

Cherry-picked from the closed chart-modernization PR #248. This is the only net-new, safe change from that PR:

- **`ephemeral-storage` requests/limits** — Kyverno policy compliance (workloads should declare ephemeral-storage).
- **`Mi` memory units** — use binary suffixes consistently.

The rest of #248 was either already shipped (`.Chart.AppVersion` label/image-tag fix) or carried a **breaking change** (rewriting the Deployment `spec.selector.matchLabels`, which is immutable and would fail `helm upgrade` on the live release), so it was left out.

## Values

| | requests | limits |
|---|---|---|
| memory | `10Mi` | `50Mi` |
| ephemeral-storage | `50Mi` | `200Mi` |

## Verification

`helm template` renders the new `ephemeral-storage` requests/limits; `helm lint` passes; values schema is valid JSON.